### PR TITLE
Fix mobile nav menu and theme toggle alignment

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,6 +43,15 @@
 
   applyTheme(getStoredTheme());
 
+  // Close hamburger menu when a nav link is clicked
+  var navTrigger = document.getElementById('nav-trigger');
+  var navLinks = document.querySelectorAll('.nav-item');
+  navLinks.forEach(function(link) {
+    link.addEventListener('click', function() {
+      navTrigger.checked = false;
+    });
+  });
+
   toggle.addEventListener('click', function() {
     var stored = getStoredTheme();
     var currentlyDark;

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -58,6 +58,15 @@
   color: $brand-color;
 }
 
+@media screen and (max-width: 600px) {
+  .theme-toggle {
+    display: block;
+    margin-left: 20px;
+    padding: 5px 10px;
+    text-align: right;
+  }
+}
+
 // Default (auto / light): show moon, hide sun
 .icon-sun  { display: none; }
 .icon-moon { display: block; }


### PR DESCRIPTION
## Summary

- Close hamburger menu when a nav link is clicked (anchor links stay on the same page so the menu wasn't closing)
- Align theme toggle with nav links in the mobile dropdown menu

## Test plan

- [ ] Narrow browser to trigger hamburger menu
- [ ] Click a nav link — menu should close and page scrolls to section
- [ ] Theme toggle should be aligned with About/Resume/Contact in the dropdown